### PR TITLE
Successfully fixed overlapping between Heading and Navbar

### DIFF
--- a/css/desktop_9.css
+++ b/css/desktop_9.css
@@ -120,7 +120,7 @@ nav {
     width: 90%;
     margin: 0 auto;
     margin-left: 112px;
-    margin-top: 30px;
+    margin-top: 130px;
 }
 
 .category {


### PR DESCRIPTION
Here is what it looked like before: 
![image](https://github.com/piug-07/blogzen-OpenSource/assets/127492462/a0c16475-58ff-4bd6-94f8-fd969e8c6fdd)
Now:
![image](https://github.com/piug-07/blogzen-OpenSource/assets/127492462/943c6a6f-898f-4762-aa66-8e4d8ece1b27)
