### PR TITLE
Fix dark mode login options visibility issue

### DIFF
--- a/css/navbar.css
+++ b/css/navbar.css
@@ -70,6 +70,10 @@ body{
 .navbar.dark {
     background-color: black;
 }
+.darktheme .overlay .popup {
+    background-color: #2c2c2c; 
+    color: #ffffff;
+}
 
 .navbar {
 


### PR DESCRIPTION
## Related Issue
 Login options are not visible in dark mode

## Description
 when we change to the dark mode theme and click on the login tab in the navbar the login option text is not visible in dark mode theme which was visible in the light mode theme 

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
![Screenshot 2024-06-08 185227](https://github.com/piug-07/blogzen-OpenSource/assets/88403341/23559395-e400-413b-8be3-7dd562ca9dac)
THIS WAS THE ISSUE 


![Screenshot 2024-06-09 194458](https://github.com/piug-07/blogzen-OpenSource/assets/88403341/ad702a3d-d600-4176-9270-3991c6e37ac0)
THIS  IS THE OUTPUT AFTER I FIXED THE ISSUE 

## Checklist:
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines outlined in the project's documentation.
- [X] I have thoroughly tested the changes before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

<!-- To check the boxes, place an 'X' inside the brackets. Example: [X] -->

## Additional Context:
[Include any additional information or context that might be helpful for reviewers. This could include details about any design decisions, potential impacts, or alternative approaches considered.]
