### PR TITLE
Fixes https://github.com/piug-07/blogzen-OpenSource/issues/574

### DIFF
--- a/css/desktop_9.css
+++ b/css/desktop_9.css
@@ -19,8 +19,8 @@
 
 }
 #themeImg{
-    width: 45px;
-    height: 45px;
+    width: 25px;
+    height: 25px;
     border: none;
     padding: 10px;
 }

--- a/css/desktop_9.css
+++ b/css/desktop_9.css
@@ -19,8 +19,8 @@
 
 }
 #themeImg{
-    width: 25px;
-    height: 25px;
+    width: 45px;
+    height: 45px;
     border: none;
     padding: 10px;
 }

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -156,6 +156,7 @@ body{
 
 
 .navs2>img {
+    box-sizing: content-box;
     cursor: pointer;
     width: 2vw;
     height: 2vw;


### PR DESCRIPTION
## Related Issue
https://github.com/piug-07/blogzen-OpenSource/issues/574

## Description
Changed logo img element in navbar to use content-box instead of border-box, as the latter causes the logo to appear small and inconsistent with the rest of the website.
 
## Type of PR

- [x ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
Attached before and after.
![image](https://github.com/piug-07/blogzen-OpenSource/assets/81289000/e9d0c12b-80f0-43f1-b85b-5a000279a3ac)
![image](https://github.com/piug-07/blogzen-OpenSource/assets/81289000/6f38267b-4473-42ed-b452-34d67cc39463)


## Checklist:
- [x ] I have performed a self-review of my code.
- [x ] I have read and followed the Contribution Guidelines outlined in the project's documentation.
- [ x] I have thoroughly tested the changes before submitting this pull request.
- [x ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.

<!-- To check the boxes, place an 'X' inside the brackets. Example: [X] -->

## Additional Context:
Fixes the logo for any page that uses border-box, no changes in appearance for pages using content-box.
